### PR TITLE
FIx weird links on event list page

### DIFF
--- a/themes/agilewarsaw/static/css/styles.css
+++ b/themes/agilewarsaw/static/css/styles.css
@@ -314,7 +314,7 @@ img.lang-icon {
 }
 
 div.all-events-list event {
-    padding: 1em;
+	padding-left: 1em;
 }
 
 div.event-info-full {


### PR DESCRIPTION
Left part of each text link on the "events" page was not active. This fix is not perfect but it works.